### PR TITLE
Made generic Item parameter a typealias in data source providers

### DIFF
--- a/Example/Example/CollectionViewController.swift
+++ b/Example/Example/CollectionViewController.swift
@@ -27,7 +27,7 @@ class CollectionViewController: UICollectionViewController {
     typealias HeaderViewFactory = TitledCollectionReusableViewFactory<CellViewModel>
     typealias Section = CollectionViewSection<CellViewModel>
 
-    var dataSourceProvider: CollectionViewDataSourceProvider<CellViewModel, Section, CellFactory, HeaderViewFactory>?
+    var dataSourceProvider: CollectionViewDataSourceProvider<Section, CellFactory, HeaderViewFactory>?
 
 
     override func viewDidLoad() {

--- a/Example/Example/TableViewController.swift
+++ b/Example/Example/TableViewController.swift
@@ -25,8 +25,7 @@ class TableViewController: UITableViewController {
 
     typealias Section = TableViewSection<CellViewModel>
     typealias CellFactory = TableViewCellFactory<UITableViewCell, CellViewModel>
-    var dataSourceProvider: TableViewDataSourceProvider<CellViewModel, Section, CellFactory>?
-
+    var dataSourceProvider: TableViewDataSourceProvider<Section, CellFactory>?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JSQDataSourcesKit/JSQDataSourcesKit/CollectionViewDataSourceProvider.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKit/CollectionViewDataSourceProvider.swift
@@ -35,9 +35,10 @@ public final class CollectionViewDataSourceProvider <
     SectionInfo: CollectionViewSectionInfo,
     CellFactory: CollectionViewCellFactoryType,
     SupplementaryViewFactory: CollectionSupplementaryViewFactoryType
-    where SectionInfo.Item == CellFactory.Item, CellFactory.Item == SupplementaryViewFactory.Item>: CustomStringConvertible {
+    where CellFactory.Item == SectionInfo.Item, SupplementaryViewFactory.Item == SectionInfo.Item>: CustomStringConvertible {
 
-    public typealias Item = CellFactory.Item
+    /// The type of elements for the data source provider.
+    public typealias Item = SectionInfo.Item
     
     // MARK: Properties
 

--- a/JSQDataSourcesKit/JSQDataSourcesKit/CollectionViewDataSourceProvider.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKit/CollectionViewDataSourceProvider.swift
@@ -32,12 +32,13 @@ A `CollectionViewDataSourceProvider` is responsible for providing a data source 
 - Adding, removing, or reloading sections as the provider's `sections` are modified
 */
 public final class CollectionViewDataSourceProvider <
-    Item,
     SectionInfo: CollectionViewSectionInfo,
     CellFactory: CollectionViewCellFactoryType,
     SupplementaryViewFactory: CollectionSupplementaryViewFactoryType
-    where SectionInfo.Item == Item, CellFactory.Item == Item, SupplementaryViewFactory.Item == Item>: CustomStringConvertible {
+    where SectionInfo.Item == CellFactory.Item, CellFactory.Item == SupplementaryViewFactory.Item>: CustomStringConvertible {
 
+    public typealias Item = CellFactory.Item
+    
     // MARK: Properties
 
     /// The sections in the collection view.

--- a/JSQDataSourcesKit/JSQDataSourcesKit/TableViewDataSourceProvider.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKit/TableViewDataSourceProvider.swift
@@ -32,9 +32,10 @@ A `TableViewDataSourceProvider` is responsible for providing a data source objec
 public final class TableViewDataSourceProvider <
     SectionInfo: TableViewSectionInfo,
     CellFactory: TableViewCellFactoryType
-    where SectionInfo.Item == CellFactory.Item>: CustomStringConvertible {
+    where CellFactory.Item == SectionInfo.Item>: CustomStringConvertible {
 
-    public typealias Item = CellFactory.Item
+    /// The type of elements for the data source provider.
+    public typealias Item = SectionInfo.Item
     
     // MARK: Properties
 

--- a/JSQDataSourcesKit/JSQDataSourcesKit/TableViewDataSourceProvider.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKit/TableViewDataSourceProvider.swift
@@ -30,11 +30,12 @@ A `TableViewDataSourceProvider` is responsible for providing a data source objec
 - Adding, removing, or reloading cells and sections as the provider's `sections` are modified.
 */
 public final class TableViewDataSourceProvider <
-    Item,
     SectionInfo: TableViewSectionInfo,
     CellFactory: TableViewCellFactoryType
-    where SectionInfo.Item == Item, CellFactory.Item == Item>: CustomStringConvertible {
+    where SectionInfo.Item == CellFactory.Item>: CustomStringConvertible {
 
+    public typealias Item = CellFactory.Item
+    
     // MARK: Properties
 
     /// The sections in the table view

--- a/JSQDataSourcesKit/JSQDataSourcesKitTests/CollectionViewDataSourceTests.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKitTests/CollectionViewDataSourceTests.swift
@@ -71,7 +71,7 @@ class CollectionViewDataSourceTests: XCTestCase {
         typealias CellFactory = CollectionViewCellFactory<FakeCollectionCell, FakeCollectionModel>
         typealias SupplementaryViewFactory = CollectionSupplementaryViewFactory<FakeCollectionSupplementaryView, FakeCollectionModel>
         typealias Section = CollectionViewSection<FakeCollectionModel>
-        typealias Provider = CollectionViewDataSourceProvider<FakeCollectionModel, Section, CellFactory, SupplementaryViewFactory>
+        typealias Provider = CollectionViewDataSourceProvider<Section, CellFactory, SupplementaryViewFactory>
 
         let dataSourceProvider: Provider = CollectionViewDataSourceProvider(sections: allSections, cellFactory: factory, collectionView: fakeCollectionView)
         let dataSource = dataSourceProvider.dataSource

--- a/JSQDataSourcesKit/JSQDataSourcesKitTests/CollectionViewFakes.swift
+++ b/JSQDataSourcesKit/JSQDataSourcesKitTests/CollectionViewFakes.swift
@@ -31,7 +31,7 @@ typealias SupplementaryViewFactory = CollectionSupplementaryViewFactory<FakeColl
 
 typealias Section = CollectionViewSection<FakeCollectionModel>
 
-typealias Provider = CollectionViewDataSourceProvider<FakeCollectionModel, Section, CellFactory, SupplementaryViewFactory>
+typealias Provider = CollectionViewDataSourceProvider<Section, CellFactory, SupplementaryViewFactory>
 
 
 struct FakeCollectionModel: Equatable, CustomStringConvertible {


### PR DESCRIPTION
Since the `Item` generic parameter in the data source providers is inferred by the `Item` types in cell, section & reusable view factories, it felt unnecessary to have to provide it when creating a data source provider.

This PR removed the generic parameter and adds it as a public typealias instead, to reduce verbosity while still keeping the type hierarchy clean.
