### PR TITLE
make DataSourceProtocol.item(atIndexPath: ) public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,31 +4,40 @@ The changelog for `JSQDataSourcesKit`. Also see the [releases](https://github.co
 
 --------------------------------------
 
+6.1.0
+-----
+
+This release closes the [6.1.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/11).
+
+## New
+
+- Added new `DataSourceProtocol` extension convenience method `func item(atIndexPath indexPath: IndexPath) -> Item?`.
+
 6.0.0
 -----
 
-This release closes the [6.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/issues?utf8=✓&q=milestone%3A6.0.0).
+This release closes the [6.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/9).
 
 **Swift 3.0 now required.**
 
 5.0.0
 -----
 
-This release closes the [5.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/issues?utf8=✓&q=milestone%3A5.0.0).
+This release closes the [5.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/8).
 
 **Swift 2.3 now required.**
 
 4.0.1
 -----
 
-This release closes the [4.0.1 milestone](https://github.com/jessesquires/JSQDataSourcesKit/issues?utf8=✓&q=milestone%3A4.0.1+).
+This release closes the [4.0.1 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/10).
 
 - Fixed an issue with `carthage build` (#61, #62). Thanks @dcaunt!
 
 4.0.0
 -----
 
-This release closes the [4.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/issues?utf8=✓&q=milestone%3A4.0.0+).
+This release closes the [4.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/7).
 
 This release is essentially a complete re-write of the library. If you are currently using this, migration to `4.0` will be pretty involved, but it will be worth it. The result is a *dramatically simpler* API.
 
@@ -109,12 +118,12 @@ The `*FetchedResultsDelegateProvider` classes have been unified into a single cl
 3.0.1
 -----
 
-Bug fixes from the [3.0.1](https://github.com/jessesquires/JSQDataSourcesKit/issues?q=milestone%3A3.0.1) milestone.
+Bug fixes from the [3.0.1](https://github.com/jessesquires/JSQDataSourcesKit/milestone/6) milestone.
 
 3.0.0
 -----
 
-This release closes the [3.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/issues?q=milestone%3A3.0.0).
+This release closes the [3.0.0 milestone](https://github.com/jessesquires/JSQDataSourcesKit/milestone/4).
 
 >**NOTE: This is actually a minor update, but there are breaking changes. Thus, the major version bump.**
 
@@ -171,7 +180,7 @@ In short, this release contains tons of refinements and fixes. The codebase is s
 
 ## Issues closed
 
-Find the complete list of closed issues [here](https://github.com/jessesquires/JSQDataSourcesKit/issues?q=milestone%3A2.0.0+is%3Aclosed) for the 2.0.0 milestone.
+Find the complete list of closed issues [here](https://github.com/jessesquires/JSQDataSourcesKit/milestone/3) for the 2.0.0 milestone.
 
 ## Documentation
 

--- a/Source/DataSource.swift
+++ b/Source/DataSource.swift
@@ -299,6 +299,6 @@ extension FetchedResultsController {
 
     /// :nodoc:
     public func item(atIndexPath indexPath: IndexPath) -> Item? {
-        return object(at: indexPath) as? T
+        return object(at: indexPath) as? Item
     }
 }

--- a/Source/DataSource.swift
+++ b/Source/DataSource.swift
@@ -294,3 +294,11 @@ extension FetchedResultsController: DataSourceProtocol {
         return nil
     }
 }
+
+extension FetchedResultsController {
+
+    /// :nodoc:
+    public func item(atIndexPath indexPath: IndexPath) -> Item? {
+        return object(at: indexPath) as? T
+    }
+}

--- a/Tests/DataSourceTests.swift
+++ b/Tests/DataSourceTests.swift
@@ -247,15 +247,16 @@ final class DataSourceTests: XCTestCase {
         let sectionB = Section(items: FakeViewModel(), FakeViewModel(), footerTitle: "Footer")
         var dataSource = DataSource(sections: sectionA, sectionB)
         
-        // WHEN: we set an item at a specific index path
+        // WHEN: we remove an item at a specific index path
         let ip = IndexPath(item: 1, section: 0)
-        let itemToRemove = dataSource.item(atIndexPath: ip)
-        
-        // THEN: Check if an item exists at the specified indexPath .Then check if the removedItem is the expected item
+        let itemToRemove = dataSource.remove(at: ip)
+
+        // THEN: the item is removed
         XCTAssertNotNil(itemToRemove)
-        
-        let removedItem = dataSource.remove(at: ip)
-        XCTAssertEqual(removedItem, itemToRemove)
+        XCTAssertEqual(dataSource.sections.count, 2)
+        XCTAssertEqual(dataSource.items(inSection: 0)?.count, 1)
+        XCTAssertEqual(dataSource.items(inSection: 1)?.count, 2)
+        XCTAssertEqual(sectionA.count, 2, "Original section should not be changed")
     }
 
     func test_thatDataSource_returnsItem_atIndexPath() {

--- a/Tests/DataSourceTests.swift
+++ b/Tests/DataSourceTests.swift
@@ -156,6 +156,27 @@ final class DataSourceTests: XCTestCase {
         XCTAssertEqual(frc[IndexPath(item: 0, section: 2)], redThings[0])
     }
 
+    func test_thatFetchedResultsController_returnsExpectedData_atIndexPath() {
+        // GIVEN: a core data stack and objects in a context
+        let context = CoreDataStack(inMemory: true).context
+        let blueThings = generateThings(context, color: .Blue)
+        let greenThings = generateThings(context, color: .Green)
+        let redThings = generateThings(context, color: .Red)
+
+        // GIVEN: a fetched results controller
+        let frc = FetchedResultsController<Thing>(fetchRequest: Thing.newFetchRequest(),
+                                                  managedObjectContext: context,
+                                                  sectionNameKeyPath: "colorName",
+                                                  cacheName: nil)
+        _ = try? frc.performFetch()
+
+        // WHEN: we ask for an object
+        // THEN: we receive the exepected data
+        XCTAssertEqual(frc.item(atIndexPath: IndexPath(item: 1, section: 0)), blueThings[1])
+        XCTAssertEqual(frc.item(atIndexPath: IndexPath(item: 2, section: 1)), greenThings[2])
+        XCTAssertEqual(frc.item(atIndexPath: IndexPath(item: 0, section: 2)), redThings[0])
+    }
+
     func test_thatDataSource_returnsExpectedData_fromIntSubscript() {
         // GIVEN: a data source
         let sectionA = Section(items: FakeViewModel(), FakeViewModel(), headerTitle: "Header")
@@ -235,5 +256,21 @@ final class DataSourceTests: XCTestCase {
         
         let removedItem = dataSource.remove(at: ip)
         XCTAssertEqual(removedItem, itemToRemove)
+    }
+
+    func test_thatDataSource_returnsItem_atIndexPath() {
+        // GIVEN: a data source
+        let model = FakeViewModel()
+        let sectionA = Section(items: FakeViewModel(), FakeViewModel(), headerTitle: "Header")
+        let sectionB = Section(items: FakeViewModel(), FakeViewModel(), footerTitle: "Footer")
+        let sectionC = Section(items: FakeViewModel(), FakeViewModel(), model)
+        let dataSource = DataSource(sections: sectionA, sectionB, sectionC)
+
+        // WHEN: we ask for an item
+        let ip = IndexPath(item: 2, section: 2)
+        let item = dataSource.item(atIndexPath: ip)
+
+        // THEN: we receive the exepected data
+        XCTAssertEqual(item, model)
     }
 }


### PR DESCRIPTION
lol whoops. 😳  This was intended to be `public`.

- Make extension method public
- Update changelog for 6.1.0
- Update changelog milestone links for new GH URLs