### PR TITLE
Simplify tableEditingController APIs

### DIFF
--- a/Example/Sources/TableViewController.swift
+++ b/Example/Sources/TableViewController.swift
@@ -53,10 +53,10 @@ final class TableViewController: UITableViewController {
         // ** optional editing **
         // if needed, enable the editing functionality on the tableView
         let tableDataSourceEditingController = TableEditingController(
-            canEditRowConfig: { (tableView, indexPath) -> Bool in
+            canEditRow: { (tableView, indexPath) -> Bool in
                 return true
         },
-            commitEditingConfig:{ [unowned self] (tableView, editingStyle, indexPath) in
+            commitEditing:{ [unowned self] (tableView, editingStyle, indexPath) in
                 if editingStyle == .delete {
                     if let _ = self.dataSourceProvider?.dataSource.remove(at: indexPath) {
                         tableView.deleteRows(at: [indexPath], with: .automatic)

--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -106,11 +106,11 @@ public extension DataSourceProvider where CellFactory.View: UITableViewCell {
 
         dataSource.tableCanEditRow = { [unowned self] (tableView, indexPath) -> Bool in
             guard let controller = self.tableEditingController else { return false }
-            return controller.canEditRow(in: tableView, at: indexPath)
+            return controller.canEditRow(tableView, indexPath)
         }
 
-        dataSource.tableCommitEditingStyleForRow = { [unowned self] (tableView, editingStyle,indexPath) in
-            self.tableEditingController?.commitEditStyleForRow(in: tableView, editingStyle: editingStyle, at: indexPath)
+        dataSource.tableCommitEditingStyleForRow = { [unowned self] (tableView, editingStyle, indexPath) in
+            self.tableEditingController?.commitEditing(tableView, editingStyle, indexPath)
         }
 
         return dataSource

--- a/Source/TableEditingController.swift
+++ b/Source/TableEditingController.swift
@@ -25,20 +25,20 @@ import UIKit
 public struct TableEditingController {
 
     // MARK: Typealiases
-    
+
     /**
      Asks if a row at the specified index path is editable for the specified table view.
-    
+
      - parameter tableView: The table view requesting this information.
      - parameter indexPath: The index path of the item.
-     
+
      - returns: `true` if the specified row is editable, `false` otherwise.
      */
     public typealias CanEditRowConfig = (_ tableView: UITableView, _ indexPath: IndexPath) -> Bool
-    
+
     /**
      Commits the editing actions for the specified index path.
-     
+
      - parameter tableView: The table view being edited.
      - parameter commit:    The editing style.
      - parameter indexPath: The index path of the item.
@@ -46,35 +46,23 @@ public struct TableEditingController {
     public typealias CommitEditingConfig = (_ tableView: UITableView, _ commit: UITableViewCellEditingStyle, _ indexPath: IndexPath) -> Void
 
     /// A closure that determines if a given row is editable.
-    public let canEditRowConfig: CanEditRowConfig
-    
+    public let canEditRow: CanEditRowConfig
+
     /// A closure that commits the editing actions for a table view.
-    public let commitEditingConfig: CommitEditingConfig
-    
+    public let commitEditing: CommitEditingConfig
+
     // MARK: Initialization
-    
+
     /**
      Constructs a new `TableEditingController`.
-     
-     - parameter canEditRowConfig:    The closure that determines if a given row is editable.
-     - parameter commitEditingConfig: The closure that commits the editing actions for a table view.
-     
+
+     - parameter canEditRow:    The closure that determines if a given row is editable.
+     - parameter commitEditing: The closure that commits the editing actions for a table view.
+
      - returns: A new `TableEditingController` instance.
      */
-    public init(canEditRowConfig: @escaping CanEditRowConfig, commitEditingConfig: @escaping CommitEditingConfig) {
-        self.canEditRowConfig = canEditRowConfig
-        self.commitEditingConfig = commitEditingConfig
-    }
-
-    // MARK: Internal
-
-    /// :nodoc:
-    func canEditRow(in tableView: UITableView, at indexPath: IndexPath) -> Bool {
-        return canEditRowConfig(tableView, indexPath)
-    }
-
-    /// :nodoc:
-    func commitEditStyleForRow(in tableView: UITableView, editingStyle: UITableViewCellEditingStyle, at indexPath: IndexPath) {
-        return commitEditingConfig(tableView, editingStyle, indexPath)
+    public init(canEditRow: @escaping CanEditRowConfig, commitEditing: @escaping CommitEditingConfig) {
+        self.canEditRow = canEditRow
+        self.commitEditing = commitEditing
     }
 }

--- a/Tests/DataSourceProviderTests.swift
+++ b/Tests/DataSourceProviderTests.swift
@@ -400,10 +400,10 @@ final class DataSourceProviderTests: TestCase {
 
         // GIVEN: a data source editing controller
         let tableDataSourceEditingController = TableEditingController(
-            canEditRowConfig: { (tableView, indexPath) -> Bool in
+            canEditRow: { (tableView, indexPath) -> Bool in
                 return indexPath == expectedIndexPath
         },
-            commitEditingConfig:{ (tableView, editingStyle, indexPath) in
+            commitEditing:{ (tableView, editingStyle, indexPath) in
                 if editingStyle == .delete {
                     if let _ = dataSourceProvider.dataSource.remove(at: indexPath) {
                         tableView.deleteRows(at: [indexPath], with: .automatic)


### PR DESCRIPTION
In reviewing #83, I realized we can simplify `TableEditingController` more.

I think @psartzetakis was following the existing patterns:

1. We pass closures
2. Those objects conform to a protocol
3. In the protocol methods, we just call the closures
4. The infra only speaks to the protocol

In the case of `TableEditingController`, **there is no protocol**. We just need to pass in these 2 closures.

So, we can remove these internal functions and just call the closure properties directly.