### PR TITLE
passing the item back to the closure for TableEditingController

### DIFF
--- a/Example/Sources/TableViewController.swift
+++ b/Example/Sources/TableViewController.swift
@@ -52,11 +52,11 @@ final class TableViewController: UITableViewController {
 
         // ** optional editing **
         // if needed, enable the editing functionality on the tableView
-        let tableDataSourceEditingController = TableEditingController(
-            canEditRow: { (tableView, indexPath) -> Bool in
+        let tableDataSourceEditingController = TableEditingController<CellViewModel>(
+            canEditRow: { (item, tableView, indexPath) -> Bool in
                 return true
         },
-            commitEditing:{ [unowned self] (tableView, editingStyle, indexPath) in
+            commitEditing:{ [unowned self] (item, tableView, editingStyle, indexPath) in
                 if editingStyle == .delete {
                     if let _ = self.dataSourceProvider?.dataSource.remove(at: indexPath) {
                         tableView.deleteRows(at: [indexPath], with: .automatic)

--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -37,7 +37,7 @@ where CellFactory.Item == DataSource.Item, SupplementaryFactory.Item == DataSour
     public let supplementaryFactory: SupplementaryFactory
 
     fileprivate var bridgedDataSource: BridgedDataSource?
-    fileprivate var _tableEditingController: TableEditingController?
+    fileprivate var _tableEditingController: TableEditingController<DataSource.Item>?
 
     // MARK: Initialization
 
@@ -73,7 +73,7 @@ public extension DataSourceProvider where CellFactory.View: UITableViewCell {
         return bridgedDataSource!
     }
 
-    public var tableEditingController: TableEditingController? {
+    public var tableEditingController: TableEditingController<DataSource.Item>? {
         set {
             _tableEditingController = newValue
         }
@@ -106,11 +106,13 @@ public extension DataSourceProvider where CellFactory.View: UITableViewCell {
 
         dataSource.tableCanEditRow = { [unowned self] (tableView, indexPath) -> Bool in
             guard let controller = self.tableEditingController else { return false }
-            return controller.canEditRow(tableView, indexPath)
+            let item = self.dataSource.item(atIndexPath: indexPath)!
+            return controller.canEditRow(item, tableView, indexPath)
         }
 
         dataSource.tableCommitEditingStyleForRow = { [unowned self] (tableView, editingStyle, indexPath) in
-            self.tableEditingController?.commitEditing(tableView, editingStyle, indexPath)
+            let item = self.dataSource.item(atIndexPath: indexPath)!
+            self.tableEditingController?.commitEditing(item, tableView, editingStyle, indexPath)
         }
 
         return dataSource

--- a/Source/TableEditingController.swift
+++ b/Source/TableEditingController.swift
@@ -22,28 +22,29 @@ import UIKit
 /**
  An instance of `TableEditingController` allows editing a table view via inserting and deleting rows.
  */
-public struct TableEditingController {
+public struct TableEditingController<Item> {
 
     // MARK: Typealiases
 
     /**
      Asks if a row at the specified index path is editable for the specified table view.
-
+     - parameter item:      The item at `indexPath`.
      - parameter tableView: The table view requesting this information.
      - parameter indexPath: The index path of the item.
 
      - returns: `true` if the specified row is editable, `false` otherwise.
      */
-    public typealias CanEditRowConfig = (_ tableView: UITableView, _ indexPath: IndexPath) -> Bool
+    public typealias CanEditRowConfig = (_ item: Item?, _ tableView: UITableView, _ indexPath: IndexPath) -> Bool
 
     /**
      Commits the editing actions for the specified index path.
 
+     - parameter item:      The item at `indexPath`.
      - parameter tableView: The table view being edited.
      - parameter commit:    The editing style.
      - parameter indexPath: The index path of the item.
      */
-    public typealias CommitEditingConfig = (_ tableView: UITableView, _ commit: UITableViewCellEditingStyle, _ indexPath: IndexPath) -> Void
+    public typealias CommitEditingConfig = ( _ item: Item?, _ tableView: UITableView, _ commit: UITableViewCellEditingStyle, _ indexPath: IndexPath) -> Void
 
     /// A closure that determines if a given row is editable.
     public let canEditRow: CanEditRowConfig

--- a/Tests/DataSourceProviderTests.swift
+++ b/Tests/DataSourceProviderTests.swift
@@ -399,11 +399,11 @@ final class DataSourceProviderTests: TestCase {
         }
 
         // GIVEN: a data source editing controller
-        let tableDataSourceEditingController = TableEditingController(
-            canEditRow: { (tableView, indexPath) -> Bool in
+        let tableDataSourceEditingController = TableEditingController<FakeViewModel>(
+            canEditRow: { (item, tableView, indexPath) -> Bool in
                 return indexPath == expectedIndexPath
         },
-            commitEditing:{ (tableView, editingStyle, indexPath) in
+            commitEditing:{ (item, tableView, editingStyle, indexPath) in
                 if editingStyle == .delete {
                     if let _ = dataSourceProvider.dataSource.remove(at: indexPath) {
                         tableView.deleteRows(at: [indexPath], with: .automatic)


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines) and [contributing guidelines](https://github.com/jessesquires/HowToContribute).

## What's in this pull request?
I was about to start doing some work on #28 , #29 and I realise that I am having the same issue that I had with the `TableEditingController`, I couldn't pass the `Item` back to the closure 😭. So I came up with a way to constraint it without touching the signature of `DataSourceProvider`. It will now explicitly ask for a `DataSource.Item` and since `CellFactory.Item == DataSource.Item` I think we are covered..🤔