### PR TITLE
Add support for data sources other than UITableViewDataSource and UICollectionViewDataSource

### DIFF
--- a/JSQDataSourcesKit.xcodeproj/project.pbxproj
+++ b/JSQDataSourcesKit.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		1D68ECA31DFFEF4600A1AFB7 /* TableEditingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD7AC5C1D86C4BC00B676A6 /* TableEditingController.swift */; };
 		1DD7AC5D1D86C4BC00B676A6 /* TableEditingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD7AC5C1D86C4BC00B676A6 /* TableEditingController.swift */; };
+		6D31F9B72003ED55005B1B0A /* DataSourceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F9B62003ED55005B1B0A /* DataSourceContainer.swift */; };
+		6D31F9BB2003FDBA005B1B0A /* DataSourceContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F9BA2003FDBA005B1B0A /* DataSourceContainerTests.swift */; };
+		6D31F9BC2003FF97005B1B0A /* DataSourceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31F9B62003ED55005B1B0A /* DataSourceContainer.swift */; };
 		881A92DB1CB881550080BC5C /* FetchedResultsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DCAD2C1CB87CB400C018AF /* FetchedResultsDelegate.swift */; };
 		881A92DD1CB881550080BC5C /* JSQDataSourcesKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 88DCAD2F1CB87CB400C018AF /* JSQDataSourcesKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		881A92E11CB881550080BC5C /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DCAD331CB87CB400C018AF /* Section.swift */; };
@@ -91,6 +94,8 @@
 
 /* Begin PBXFileReference section */
 		1DD7AC5C1D86C4BC00B676A6 /* TableEditingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableEditingController.swift; sourceTree = "<group>"; };
+		6D31F9B62003ED55005B1B0A /* DataSourceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceContainer.swift; sourceTree = "<group>"; };
+		6D31F9BA2003FDBA005B1B0A /* DataSourceContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceContainerTests.swift; sourceTree = "<group>"; };
 		881A92CC1CB881270080BC5C /* JSQDataSourcesKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSQDataSourcesKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88253C511FFAF5C20022FCA8 /* DataSourceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceProtocol.swift; sourceTree = "<group>"; };
 		88253C531FFAF7730022FCA8 /* FetchedResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsController.swift; sourceTree = "<group>"; };
@@ -183,6 +188,7 @@
 				88C99A761CBB302600A9804A /* BridgedDataSource.swift */,
 				882CA4531D1D7D48006112B9 /* BridgedFetchedResultsDelegate.swift */,
 				888799481D0E2D1700BBCCBC /* DataSource.swift */,
+				6D31F9B62003ED55005B1B0A /* DataSourceContainer.swift */,
 				88253C511FFAF5C20022FCA8 /* DataSourceProtocol.swift */,
 				88B80CD71CBBF62A00EDF9D5 /* DataSourceProvider.swift */,
 				88253C531FFAF7730022FCA8 /* FetchedResultsController.swift */,
@@ -203,6 +209,7 @@
 			children = (
 				88C99A7A1CBB628A00A9804A /* BridgedDataSourceTests.swift */,
 				882CA4591D1D957A006112B9 /* BridgedFetchedResultsDelegateTests.swift */,
+				6D31F9BA2003FDBA005B1B0A /* DataSourceContainerTests.swift */,
 				88DCAD391CB87CB400C018AF /* DataSourceProviderSubscriptTests.swift */,
 				88DCAD3A1CB87CB400C018AF /* DataSourceProviderTests.swift */,
 				882CA45E1D1EE1EA006112B9 /* DataSourceTests.swift */,
@@ -418,6 +425,7 @@
 				88C99A791CBB303000A9804A /* BridgedDataSource.swift in Sources */,
 				881A92E51CB881550080BC5C /* TitledSupplementaryViewConfig.swift in Sources */,
 				88253C551FFAF7730022FCA8 /* FetchedResultsController.swift in Sources */,
+				6D31F9BC2003FF97005B1B0A /* DataSourceContainer.swift in Sources */,
 				88B80CD91CBBF62A00EDF9D5 /* DataSourceProvider.swift in Sources */,
 				882CA4551D1D7DE1006112B9 /* BridgedFetchedResultsDelegate.swift in Sources */,
 				882CA4561D1D7DE1006112B9 /* DataSource.swift in Sources */,
@@ -437,6 +445,7 @@
 				88C99A771CBB302600A9804A /* BridgedDataSource.swift in Sources */,
 				88DCAD761CB87CC000C018AF /* TitledSupplementaryView.swift in Sources */,
 				88DCAD741CB87CC000C018AF /* Section.swift in Sources */,
+				6D31F9B72003ED55005B1B0A /* DataSourceContainer.swift in Sources */,
 				88B80CD81CBBF62A00EDF9D5 /* DataSourceProvider.swift in Sources */,
 				1DD7AC5D1D86C4BC00B676A6 /* TableEditingController.swift in Sources */,
 				888799491D0E2D1700BBCCBC /* DataSource.swift in Sources */,
@@ -459,6 +468,7 @@
 				88DCAD821CB87CC900C018AF /* SectionTests.swift in Sources */,
 				88DCAD7A1CB87CC900C018AF /* DataSourceProviderTests.swift in Sources */,
 				88DCAD7B1CB87CC900C018AF /* TestHelpers.swift in Sources */,
+				6D31F9BB2003FDBA005B1B0A /* DataSourceContainerTests.swift in Sources */,
 				882CA45A1D1D957A006112B9 /* BridgedFetchedResultsDelegateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/DataSourceContainer.swift
+++ b/Source/DataSourceContainer.swift
@@ -1,0 +1,59 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//
+//  Documentation
+//  https://jessesquires.github.io/JSQDataSourcesKit
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQDataSourcesKit
+//
+//
+//  License
+//  Copyright © 2015-present Jesse Squires
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+// 
+
+import Foundation
+
+/// A `DataSourceContainer` is a map of generic data source implementations, keyed by their type.
+public struct DataSourceContainer {
+
+    private var map: Dictionary<String, Any> = [:]
+    
+    /// Add a data source implementation to the container. The data
+    /// source can be retrieved using the type of the object. Its easier
+    /// to keep track of the type of the data source by explicitly casting
+    /// it to the protocol it implements (i.e UITableViewDataSource/UICollectionViewDataSource)
+    ///
+    /// - Parameter dataSource: the data source implementation to add
+    public mutating func add<T>(dataSource: T)
+    {
+        map[key(for: T.self)] = dataSource
+    }
+    
+    /// Retrieves a previously added data source implementation of the specified
+    /// type, or nil if no implementation has been added.
+    ///
+    /// - Parameter dataSourceType: The type of the data source to retrieve
+    public subscript<T> (dataSourceType: T.Type) -> T?
+    {
+        get {
+            guard let value = map[key(for: dataSourceType)] else {
+                return nil
+            }
+            guard let dataSource = value as? T else {
+                // This *shouldn't* ever happen
+                preconditionFailure("Received unexpected dataSource \(value). Expected object of type \(dataSourceType)")
+            }
+            return dataSource
+        }
+    }
+    
+    private func key<T>(for dataSourceType: T.Type) -> String
+    {
+        return String(describing: dataSourceType)
+    }
+}

--- a/Source/DataSourceProvider.swift
+++ b/Source/DataSourceProvider.swift
@@ -36,7 +36,8 @@ where CellConfig.Item == DataSource.Item, SupplementaryConfig.Item == DataSource
     /// The supplementary view configuration.
     public let supplementaryConfig: SupplementaryConfig
 
-    private var bridgedDataSource: BridgedDataSource?
+    /// The container holding the data source implementation
+    public var dataSourceContainer: DataSourceContainer = DataSourceContainer()
 
     private var tableEditingController: TableEditingController<DataSource>?
 
@@ -86,10 +87,13 @@ public extension DataSourceProvider where CellConfig.View: UITableViewCell {
 
     /// Returns the `UITableViewDataSource` object.
     public var tableViewDataSource: UITableViewDataSource {
-        if bridgedDataSource == nil {
-            bridgedDataSource = tableViewBridgedDataSource()
+        if let tableViewDataSource = dataSourceContainer[UITableViewDataSource.self] {
+            return tableViewDataSource
         }
-        return bridgedDataSource!
+        
+        let tableViewDataSource = tableViewBridgedDataSource()
+        dataSourceContainer.add(dataSource: tableViewDataSource as UITableViewDataSource)
+        return tableViewDataSource
     }
 
     private func tableViewBridgedDataSource() -> BridgedDataSource {
@@ -134,10 +138,13 @@ public extension DataSourceProvider where CellConfig.View: UICollectionViewCell,
 
     /// Returns the `UICollectionViewDataSource` object.
     public var collectionViewDataSource: UICollectionViewDataSource {
-        if bridgedDataSource == nil {
-            bridgedDataSource = collectionViewBridgedDataSource()
+        if let collectionViewDataSource = dataSourceContainer[UICollectionViewDataSource.self] {
+            return collectionViewDataSource
         }
-        return bridgedDataSource!
+        
+        let collectionViewDataSource = collectionViewBridgedDataSource()
+        dataSourceContainer.add(dataSource: collectionViewDataSource as UICollectionViewDataSource)
+        return collectionViewDataSource
     }
 
     private func collectionViewBridgedDataSource() -> BridgedDataSource {

--- a/Tests/DataSourceContainerTests.swift
+++ b/Tests/DataSourceContainerTests.swift
@@ -1,0 +1,73 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//
+//  Documentation
+//  https://jessesquires.github.io/JSQDataSourcesKit
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQDataSourcesKit
+//
+//
+//  License
+//  Copyright © 2015-present Jesse Squires
+//  Released under an MIT license: https://opensource.org/licenses/MIT
+// 
+
+import XCTest
+
+@testable import JSQDataSourcesKit
+
+class DataSourceContainerTests: XCTestCase {
+    
+    private class FakeTableViewDataSource: NSObject, UITableViewDataSource {
+        
+        func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+            return 0
+        }
+        
+        func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+            return UITableViewCell()
+        }
+    }
+    
+    private class FakeCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+        
+        func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            return 0
+        }
+        
+        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            return UICollectionViewCell()
+        }
+    }
+    
+    func test_thatDataSourceContainer_returnsExpectedDataSource_forAddedDataSources() {
+        
+        let tableViewDatasource: UITableViewDataSource = FakeTableViewDataSource()
+        let collectionViewDatasource: UICollectionViewDataSource = FakeCollectionViewDataSource()
+        
+        var container = DataSourceContainer()
+        container.add(dataSource: tableViewDatasource)
+        container.add(dataSource: collectionViewDatasource)
+        
+        let tableViewResult = container[UITableViewDataSource.self]
+        let collectionViewResult = container[UICollectionViewDataSource.self]
+        
+        XCTAssert(tableViewDatasource === tableViewResult)
+        XCTAssert(collectionViewDatasource === collectionViewResult)
+    }
+    
+    func test_thatDataSourceContainer_returnsNoDataSource_ifNotAdded() {
+        
+        let container = DataSourceContainer()
+        
+        let tableViewResult = container[UITableViewDataSource.self]
+        let collectionViewResult = container[UICollectionViewDataSource.self]
+        
+        XCTAssertNil(tableViewResult)
+        XCTAssertNil(collectionViewResult)
+    }
+}


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines) and [contributing guidelines](https://github.com/jessesquires/HowToContribute).

## What's in this pull request?

The library currently only supports UICollectionView and UITableView data sources. This pull request provides a method to support other views that have a similar design pattern, such as [SpreadsheetView](https://github.com/kishikawakatsumi/SpreadsheetView). I can provide a sample project to show how to do it, but it's pretty straightforward if you look at the code.

## Justification
The `BridgedDataSource` class is currently internal, and therefore so is the property in `DataSourceProvider`. This makes it difficult/impossible for it to be extended to conform to the required data source protocol (such as `SpreadsheetViewDataSource`, from the repo listed above), or for the `DataSourceProvider` to be extended to hold a reference to the data source implementation.

## Changes

I added a `DataSourceContainer` class that encapsulates the object conforming to the data source protocol. So this will hold the `UITableViewDataSource`, `UICollectionViewDataSource`, or the custom data source you're trying to add support for. Then instead of the `DataSourceProtocol` keeping a reference to the `BridgedDataSource`, it holds a reference to a `DataSourceContainer`. When the data source is requested using the `tableViewDataSource` property, `collectionViewDataSource` property, or some other data source property you've added in in an extension, it will query the `DataSourceContainer` for the data source for the appropriate protocol (and creating one and adding it to the container if necessary).